### PR TITLE
Fixed INITIAL_SUPPLY value

### DIFF
--- a/contracts/BotCoin.sol
+++ b/contracts/BotCoin.sol
@@ -9,7 +9,7 @@ contract BotCoin is StandardToken {
 	string public name = 'BotCoin';
 	string public symbol = 'BOT';
 	uint public decimals = 18;
-	uint public INITIAL_SUPPLY = 1.5 * 10^9;
+	uint public INITIAL_SUPPLY = 1.5 * 10**9;
 
 	function BotCoin() public {
 	  totalSupply_ = INITIAL_SUPPLY * (10 ** decimals);


### PR DESCRIPTION
Due to this bug existing ERC20 contract issued only 6 BOT coins instead of 1.5 billion.